### PR TITLE
Implement mock login usecase and register dependency

### DIFF
--- a/lib/app/bindings/initial_binding.dart
+++ b/lib/app/bindings/initial_binding.dart
@@ -1,10 +1,14 @@
 import 'package:get/get.dart';
+import '../../features/auth/domain/usecases/login_usecase.dart';
 import '../../features/auth/presentation/controllers/auth_controller.dart';
 import '../../features/home/presentation/controllers/home_controller.dart';
 
 class InitialBinding extends Bindings {
   @override
   void dependencies() {
+    // Core dependencies
+    Get.put<LoginUsecase>(LoginUsecase(), permanent: true);
+
     // Core controllers
     Get.put<AuthController>(AuthController(), permanent: true);
     Get.put<HomeController>(HomeController(), permanent: true);

--- a/lib/features/auth/domain/usecases/login_usecase.dart
+++ b/lib/features/auth/domain/usecases/login_usecase.dart
@@ -1,0 +1,37 @@
+import '../../../../shared/domain/entities/user.dart';
+
+class LoginResult {
+  final bool isSuccess;
+  final User? user;
+  final String? token;
+  final String? message;
+
+  LoginResult({
+    required this.isSuccess,
+    this.user,
+    this.token,
+    this.message,
+  });
+}
+
+class LoginUsecase {
+  Future<LoginResult> call(String email, String password) async {
+    await Future.delayed(const Duration(milliseconds: 300));
+
+    if (email == 'user@example.com' && password == 'password') {
+      final user = User(
+        id: '1',
+        name: 'Example User',
+        email: email,
+        phone: '0800000000',
+        createdAt: DateTime.now(),
+      );
+      return LoginResult(isSuccess: true, user: user, token: 'mock_token_1');
+    }
+
+    return LoginResult(
+      isSuccess: false,
+      message: 'Invalid email or password',
+    );
+  }
+}

--- a/test/login_usecase_test.dart
+++ b/test/login_usecase_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trevelin_mobile_app/features/auth/domain/usecases/login_usecase.dart';
+import 'package:trevelin_mobile_app/shared/domain/entities/user.dart';
+
+void main() {
+  final usecase = LoginUsecase();
+
+  test('returns user and token for valid credentials', () async {
+    final result = await usecase.call('user@example.com', 'password');
+    expect(result.isSuccess, isTrue);
+    expect(result.user, isA<User>());
+    expect(result.token, isNotNull);
+  });
+
+  test('fails for invalid credentials', () async {
+    final result = await usecase.call('wrong@example.com', 'invalid');
+    expect(result.isSuccess, isFalse);
+    expect(result.user, isNull);
+    expect(result.token, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add mock `LoginUsecase` for authentication flows
- register `LoginUsecase` in initial binding
- add unit test for login use case

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dded91dc48327aab11423771297e6