### PR TITLE
feat: add mock payment phase

### DIFF
--- a/lib/core/routes/app_routes.dart
+++ b/lib/core/routes/app_routes.dart
@@ -5,6 +5,8 @@ import '../../features/speedboat/presentation/pages/seat_map_page.dart';
 import '../../features/speedboat/presentation/pages/booking_checkout_page.dart';
 import '../../features/speedboat/presentation/pages/booking_success_page.dart';
 import '../../features/packages/presentation/pages/package_detail_page.dart';
+import '../../features/payments/presentation/pages/payment_method_page.dart';
+import '../../features/payments/presentation/pages/payment_pending_page.dart';
 
 /// Application route names and GetX pages.
 class AppRoutes {
@@ -15,6 +17,8 @@ class AppRoutes {
   static const String seatMap = '/speedboat/:id/seat-map';
   static const String checkout = '/speedboat/checkout';
   static const String bookingSuccess = '/speedboat/success';
+  static const String paymentMethod = '/payment/method';
+  static const String paymentPending = '/payment/pending';
   static const String packageDetail = '/package/:id';
 
   /// List of [GetPage] for GetMaterialApp.
@@ -24,6 +28,8 @@ class AppRoutes {
     GetPage(name: seatMap, page: () => const SeatMapPage()),
     GetPage(name: checkout, page: () => const BookingCheckoutPage()),
     GetPage(name: bookingSuccess, page: () => const BookingSuccessPage()),
+    GetPage(name: paymentMethod, page: () => const PaymentMethodPage()),
+    GetPage(name: paymentPending, page: () => const PaymentPendingPage()),
     GetPage(name: packageDetail, page: () => const PackageDetailPage()),
   ];
 }

--- a/lib/core/utils/idempotency.dart
+++ b/lib/core/utils/idempotency.dart
@@ -1,0 +1,16 @@
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
+
+import '../../features/payments/domain/entities/payment_method.dart';
+
+/// Creates a deterministic idempotency key based on booking and method info.
+String createIdempotencyKey(
+  String bookingId,
+  int amount,
+  PaymentMethod method,
+) {
+  final bucket = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 60000; // minute bucket
+  final raw =
+      '$bookingId|$amount|${method.channel.name}|${method.bankCode ?? ''}|${method.ewalletType ?? ''}|$bucket';
+  return sha1.convert(utf8.encode(raw)).toString();
+}

--- a/lib/core/utils/retry.dart
+++ b/lib/core/utils/retry.dart
@@ -1,0 +1,20 @@
+/// Retry a future-returning function with exponential backoff.
+Future<T> retryWithBackoff<T>(
+  Future<T> Function() fn, {
+  int maxAttempts = 6,
+}) async {
+  var attempt = 0;
+  var delay = const Duration(seconds: 1);
+  late T result;
+  while (true) {
+    try {
+      result = await fn();
+      return result;
+    } catch (_) {
+      attempt++;
+      if (attempt >= maxAttempts) rethrow;
+      await Future.delayed(delay);
+      delay *= 2;
+    }
+  }
+}

--- a/lib/features/payments/data/datasources/payment_gateway_mock.dart
+++ b/lib/features/payments/data/datasources/payment_gateway_mock.dart
@@ -1,0 +1,99 @@
+import 'dart:math';
+
+import 'package:uuid/uuid.dart';
+
+import '../../domain/entities/payment_intent.dart';
+import '../../domain/entities/payment_method.dart';
+import '../../domain/entities/payment_status.dart';
+import '../../domain/services/payment_gateway.dart';
+
+class PaymentGatewayMock implements PaymentGateway {
+  PaymentGatewayMock({this.onWebhook});
+
+  final void Function(Map<String, dynamic> payload)? onWebhook;
+  final _uuid = const Uuid();
+  final _rng = Random();
+  final Map<String, PaymentIntent> _intents = {};
+  final Map<String, String> _idempotency = {};
+
+  @override
+  Future<PaymentIntent> createIntent({
+    required String bookingId,
+    required int amount,
+    required PaymentMethod method,
+    required String idempotencyKey,
+    Map<String, dynamic>? metadata,
+  }) async {
+    if (_idempotency.containsKey(idempotencyKey)) {
+      return _intents[_idempotency[idempotencyKey]!]!;
+    }
+    final id = _uuid.v4();
+    final now = DateTime.now();
+    final expires = now.add(const Duration(minutes: 30));
+    PaymentStatus status =
+        (method.channel == PaymentChannel.ewallet || method.channel == PaymentChannel.card)
+            ? PaymentStatus.requiresAction
+            : PaymentStatus.pending;
+    String? va;
+    String? redirect;
+    String? qris;
+    switch (method.channel) {
+      case PaymentChannel.va:
+        va = '8808-${_rng.nextInt(90000000) + 10000000}';
+        break;
+      case PaymentChannel.ewallet:
+      case PaymentChannel.card:
+        redirect = 'https://mock.pay/redirect/$id';
+        break;
+      case PaymentChannel.qris:
+        qris = '000201010212MOCK$id';
+        break;
+    }
+    final intent = PaymentIntent(
+      id: id,
+      bookingId: bookingId,
+      amount: amount,
+      method: method,
+      status: status,
+      redirectUrl: redirect,
+      vaNumber: va,
+      qrisPayload: qris,
+      createdAt: now,
+      expiresAt: expires,
+    );
+    _intents[id] = intent;
+    _idempotency[idempotencyKey] = id;
+    return intent;
+  }
+
+  @override
+  Future<PaymentIntent> getIntent(String paymentId) async {
+    final intent = _intents[paymentId];
+    if (intent == null) throw Exception('not found');
+    return intent;
+  }
+
+  @override
+  Future<void> simulateProviderSetPaid(String paymentId) async {
+    final current = _intents[paymentId];
+    if (current == null) return;
+    final updated = PaymentIntent(
+      id: current.id,
+      bookingId: current.bookingId,
+      amount: current.amount,
+      method: current.method,
+      status: PaymentStatus.paid,
+      redirectUrl: current.redirectUrl,
+      vaNumber: current.vaNumber,
+      qrisPayload: current.qrisPayload,
+      createdAt: current.createdAt,
+      expiresAt: current.expiresAt,
+    );
+    _intents[paymentId] = updated;
+    onWebhook?.call({
+      'type': 'payment.paid',
+      'data': {'paymentId': paymentId, 'status': 'paid'},
+      'signature': 'mock',
+    });
+  }
+}

--- a/lib/features/payments/data/models/payment_intent_model.dart
+++ b/lib/features/payments/data/models/payment_intent_model.dart
@@ -1,0 +1,89 @@
+import '../../domain/entities/payment_intent.dart';
+import '../../domain/entities/payment_method.dart';
+import '../../domain/entities/payment_status.dart';
+
+class PaymentIntentModel {
+  PaymentIntentModel({
+    required this.id,
+    required this.bookingId,
+    required this.amount,
+    required this.method,
+    required this.status,
+    this.redirectUrl,
+    this.vaNumber,
+    this.qrisPayload,
+    required this.createdAt,
+    required this.expiresAt,
+  });
+
+  final String id;
+  final String bookingId;
+  final int amount;
+  final PaymentMethod method;
+  final PaymentStatus status;
+  final String? redirectUrl;
+  final String? vaNumber;
+  final String? qrisPayload;
+  final DateTime createdAt;
+  final DateTime expiresAt;
+
+  factory PaymentIntentModel.fromEntity(PaymentIntent e) => PaymentIntentModel(
+        id: e.id,
+        bookingId: e.bookingId,
+        amount: e.amount,
+        method: e.method,
+        status: e.status,
+        redirectUrl: e.redirectUrl,
+        vaNumber: e.vaNumber,
+        qrisPayload: e.qrisPayload,
+        createdAt: e.createdAt,
+        expiresAt: e.expiresAt,
+      );
+
+  PaymentIntent toEntity() => PaymentIntent(
+        id: id,
+        bookingId: bookingId,
+        amount: amount,
+        method: method,
+        status: status,
+        redirectUrl: redirectUrl,
+        vaNumber: vaNumber,
+        qrisPayload: qrisPayload,
+        createdAt: createdAt,
+        expiresAt: expiresAt,
+      );
+
+  factory PaymentIntentModel.fromJson(Map<String, dynamic> json) => PaymentIntentModel(
+        id: json['id'] as String,
+        bookingId: json['bookingId'] as String,
+        amount: json['amount'] as int,
+        method: PaymentMethod(
+          channel: PaymentChannel.values.firstWhere(
+              (e) => e.name == json['channel'] as String),
+          bankCode: json['bankCode'] as String?,
+          ewalletType: json['ewalletType'] as String?,
+        ),
+        status: PaymentStatus.values
+            .firstWhere((e) => e.name == json['status'] as String),
+        redirectUrl: json['redirectUrl'] as String?,
+        vaNumber: json['vaNumber'] as String?,
+        qrisPayload: json['qrisPayload'] as String?,
+        createdAt: DateTime.parse(json['createdAt'] as String),
+        expiresAt: DateTime.parse(json['expiresAt'] as String),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'bookingId': bookingId,
+        'amount': amount,
+        'channel': method.channel.name,
+        'bankCode': method.bankCode,
+        'ewalletType': method.ewalletType,
+        'status': status.name,
+        'redirectUrl': redirectUrl,
+        'vaNumber': vaNumber,
+        'qrisPayload': qrisPayload,
+        'createdAt': createdAt.toIso8601String(),
+        'expiresAt': expiresAt.toIso8601String(),
+      };
+}

--- a/lib/features/payments/data/repositories/payment_repo_impl.dart
+++ b/lib/features/payments/data/repositories/payment_repo_impl.dart
@@ -1,0 +1,108 @@
+import '../../../../core/utils/idempotency.dart';
+import '../../../../core/utils/result.dart';
+import '../../domain/entities/payment_intent.dart';
+import '../../domain/entities/payment_method.dart';
+import '../../domain/entities/payment_status.dart';
+import '../../domain/repositories/payment_repo.dart';
+import '../../domain/services/payment_gateway.dart';
+import '../../../speedboat/domain/repositories/speedboat_repo.dart';
+import '../../../../data/storage/local_store.dart';
+
+/// Implementation of [PaymentRepository] wrapping a [PaymentGateway].
+class PaymentRepositoryImpl implements PaymentRepository {
+  PaymentRepositoryImpl({
+    required this.gateway,
+    required this.store,
+    required this.bookingRepo,
+  });
+
+  final PaymentGateway gateway;
+  final LocalStore store;
+  final SpeedboatRepo bookingRepo;
+
+  @override
+  Future<Result<PaymentIntent>> createIntent({
+    required String bookingId,
+    required int amount,
+    required PaymentMethod method,
+    String? idempotencyKey,
+    Map<String, dynamic>? metadata,
+  }) async {
+    try {
+      final key = idempotencyKey ??
+          createIdempotencyKey(bookingId, amount, method);
+      final intent = await gateway.createIntent(
+        bookingId: bookingId,
+        amount: amount,
+        method: method,
+        idempotencyKey: key,
+        metadata: metadata,
+      );
+      return Result.success(intent);
+    } catch (e) {
+      return Result.failure(e);
+    }
+  }
+
+  @override
+  Future<Result<PaymentIntent>> getIntent(String paymentId) async {
+    try {
+      final intent = await gateway.getIntent(paymentId);
+      return Result.success(intent);
+    } catch (e) {
+      return Result.failure(e);
+    }
+  }
+
+  @override
+  Future<Result<PaymentStatus>> pollStatus({
+    required String paymentId,
+    Duration totalTimeout = const Duration(minutes: 2),
+  }) async {
+    final end = DateTime.now().add(totalTimeout);
+    var delay = const Duration(seconds: 1);
+    while (DateTime.now().isBefore(end)) {
+      try {
+        final intent = await gateway.getIntent(paymentId);
+        final status = intent.status;
+        if (status == PaymentStatus.paid ||
+            status == PaymentStatus.failed ||
+            status == PaymentStatus.cancelled ||
+            status == PaymentStatus.expired) {
+          if (status == PaymentStatus.paid) {
+            await bookingRepo.confirmBooking(intent.bookingId);
+            await store.write('lastPaymentId', paymentId);
+          }
+          return Result.success(status);
+        }
+      } catch (e) {
+        return Result.failure(e);
+      }
+      await Future.delayed(delay);
+      delay *= 2;
+    }
+    return Result.failure('timeout');
+  }
+
+  @override
+  Future<Result<void>> handleWebhook(Map<String, dynamic> payload) async {
+    try {
+      final data = payload['data'] as Map<String, dynamic>;
+      final paymentId = data['paymentId'] as String;
+      final key = 'webhook:$paymentId:done';
+      if (store.read<bool>(key) == true) {
+        return Result.success(null);
+      }
+      final status = data['status'] as String?;
+      if (status == 'paid') {
+        final intent = await gateway.getIntent(paymentId);
+        await bookingRepo.confirmBooking(intent.bookingId);
+        await store.write('lastPaymentId', paymentId);
+      }
+      await store.write(key, true);
+      return Result.success(null);
+    } catch (e) {
+      return Result.failure(e);
+    }
+  }
+}

--- a/lib/features/payments/domain/entities/payment_intent.dart
+++ b/lib/features/payments/domain/entities/payment_intent.dart
@@ -1,0 +1,27 @@
+import 'payment_method.dart';
+import 'payment_status.dart';
+
+class PaymentIntent {
+  final String id;                 // payment_id from provider
+  final String bookingId;
+  final int amount;
+  final PaymentMethod method;
+  final PaymentStatus status;
+  final String? redirectUrl;       // ewallet/card
+  final String? vaNumber;          // VA
+  final String? qrisPayload;       // QR string to render
+  final DateTime createdAt;
+  final DateTime expiresAt;
+  const PaymentIntent({
+    required this.id,
+    required this.bookingId,
+    required this.amount,
+    required this.method,
+    required this.status,
+    this.redirectUrl,
+    this.vaNumber,
+    this.qrisPayload,
+    required this.createdAt,
+    required this.expiresAt,
+  });
+}

--- a/lib/features/payments/domain/entities/payment_method.dart
+++ b/lib/features/payments/domain/entities/payment_method.dart
@@ -1,0 +1,8 @@
+enum PaymentChannel { va, ewallet, qris, card }
+
+class PaymentMethod {
+  final PaymentChannel channel;
+  final String? bankCode;      // for VA
+  final String? ewalletType;   // ex: OVO, DANA
+  const PaymentMethod({required this.channel, this.bankCode, this.ewalletType});
+}

--- a/lib/features/payments/domain/entities/payment_status.dart
+++ b/lib/features/payments/domain/entities/payment_status.dart
@@ -1,0 +1,1 @@
+enum PaymentStatus { requiresAction, pending, paid, failed, cancelled, expired }

--- a/lib/features/payments/domain/repositories/payment_repo.dart
+++ b/lib/features/payments/domain/repositories/payment_repo.dart
@@ -1,0 +1,25 @@
+import '../../../../core/utils/result.dart';
+import '../entities/payment_intent.dart';
+import '../entities/payment_method.dart';
+import '../entities/payment_status.dart';
+
+abstract class PaymentRepository {
+  Future<Result<PaymentIntent>> createIntent({
+    required String bookingId,
+    required int amount,
+    required PaymentMethod method,
+    String? idempotencyKey, // to avoid dup intents
+    Map<String, dynamic>? metadata,
+  });
+
+  Future<Result<PaymentIntent>> getIntent(String paymentId);
+
+  /// Poll provider for status updates with exponential backoff.
+  Future<Result<PaymentStatus>> pollStatus({
+    required String paymentId,
+    Duration totalTimeout = const Duration(minutes: 2),
+  });
+
+  /// Handle webhook payload (mock for now). Must be idempotent.
+  Future<Result<void>> handleWebhook(Map<String, dynamic> payload);
+}

--- a/lib/features/payments/domain/services/payment_gateway.dart
+++ b/lib/features/payments/domain/services/payment_gateway.dart
@@ -1,0 +1,17 @@
+import '../entities/payment_intent.dart';
+import '../entities/payment_method.dart';
+
+abstract class PaymentGateway {
+  Future<PaymentIntent> createIntent({
+    required String bookingId,
+    required int amount,
+    required PaymentMethod method,
+    required String idempotencyKey,
+    Map<String, dynamic>? metadata,
+  });
+
+  Future<PaymentIntent> getIntent(String paymentId);
+
+  /// Simulates provider-side async update; real impl will be triggered via webhook.
+  Future<void> simulateProviderSetPaid(String paymentId); // mock only
+}

--- a/lib/features/payments/presentation/controllers/payment_controller.dart
+++ b/lib/features/payments/presentation/controllers/payment_controller.dart
@@ -1,0 +1,70 @@
+import 'package:get/get.dart';
+
+import '../../domain/entities/payment_intent.dart';
+import '../../domain/entities/payment_method.dart';
+import '../../domain/entities/payment_status.dart';
+import '../../domain/repositories/payment_repo.dart';
+import '../../../../core/utils/idempotency.dart';
+import '../../../speedboat/presentation/controllers/speedboat_controller.dart';
+import '../../data/repositories/payment_repo_impl.dart';
+
+class PaymentController extends GetxController {
+  PaymentController(this.repo);
+
+  final PaymentRepository repo;
+
+  Rx<PaymentMethod?> selected = Rx<PaymentMethod?>(null);
+  Rx<PaymentIntent?> intent = Rx<PaymentIntent?>(null);
+  Rx<PaymentStatus> status = PaymentStatus.pending.obs;
+
+  Future<void> chooseMethod(PaymentMethod m) async {
+    selected.value = m;
+  }
+
+  Future<void> createAndStart({
+    required String bookingId,
+    required int amount,
+  }) async {
+    final method = selected.value!;
+    final idk = createIdempotencyKey(bookingId, amount, method);
+    final res = await repo.createIntent(
+      bookingId: bookingId,
+      amount: amount,
+      method: method,
+      idempotencyKey: idk,
+    );
+    if (res.isSuccess) {
+      final ok = res.data!;
+      intent.value = ok;
+      status.value = ok.status;
+      Future.delayed(const Duration(seconds: 2), () async {
+        await (repo as PaymentRepositoryImpl)
+            .gateway
+            .simulateProviderSetPaid(ok.id);
+      });
+    } else {
+      Get.snackbar('Payment', 'Failed: ${res.error}');
+    }
+  }
+
+  Future<void> pollUntilDone() async {
+    final id = intent.value!.id;
+    final s = await repo.pollStatus(
+        paymentId: id, totalTimeout: const Duration(seconds: 30));
+    if (s.isSuccess) {
+      status.value = s.data!;
+      if (status.value == PaymentStatus.paid) {
+        final sb = Get.find<SpeedboatController>();
+        final intentVal = intent.value!;
+        final confirm = await (repo as PaymentRepositoryImpl)
+            .bookingRepo
+            .confirmBooking(intentVal.bookingId);
+        if (confirm.isSuccess) {
+          sb.booking.value = confirm.data;
+        }
+      }
+    } else {
+      Get.snackbar('Payment', 'Poll error: ${s.error}');
+    }
+  }
+}

--- a/lib/features/payments/presentation/pages/payment_method_page.dart
+++ b/lib/features/payments/presentation/pages/payment_method_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controllers/payment_controller.dart';
+import '../widgets/payment_channel_picker.dart';
+import '../../../speedboat/presentation/controllers/speedboat_controller.dart';
+import '../../../../core/routes/app_routes.dart';
+
+class PaymentMethodPage extends GetView<PaymentController> {
+  const PaymentMethodPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final sb = Get.find<SpeedboatController>();
+    final booking = sb.booking.value;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Payment Method')),
+      body: booking == null
+          ? const Center(child: Text('No booking'))
+          : Column(
+              children: [
+                PaymentChannelPicker(
+                  onSelected: controller.chooseMethod,
+                ),
+                const Spacer(),
+                Obx(() => ElevatedButton(
+                      onPressed: controller.selected.value == null
+                          ? null
+                          : () async {
+                              await controller.createAndStart(
+                                bookingId: booking.id,
+                                amount: booking.amount,
+                              );
+                              Get.toNamed(AppRoutes.paymentPending);
+                            },
+                      child: const Text('Continue'),
+                    )),
+                const SizedBox(height: 16),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/features/payments/presentation/pages/payment_pending_page.dart
+++ b/lib/features/payments/presentation/pages/payment_pending_page.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../domain/entities/payment_status.dart';
+import '../../domain/entities/payment_method.dart';
+import '../controllers/payment_controller.dart';
+import '../../../../core/routes/app_routes.dart';
+
+class PaymentPendingPage extends GetView<PaymentController> {
+  const PaymentPendingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Complete Payment')),
+      body: Obx(() {
+        final intent = controller.intent.value;
+        if (intent == null) {
+          return const Center(child: Text('No payment'));
+        }
+        final widgets = <Widget>[
+          Text('Amount: ${intent.amount}'),
+        ];
+        switch (intent.method.channel) {
+          case PaymentChannel.va:
+            widgets.add(Text('VA Number: ${intent.vaNumber}'));
+            break;
+          case PaymentChannel.ewallet:
+          case PaymentChannel.card:
+            widgets.add(Text('Redirect: ${intent.redirectUrl}'));
+            break;
+          case PaymentChannel.qris:
+            widgets.add(Text('QRIS: ${intent.qrisPayload}'));
+            break;
+        }
+        widgets.add(const SizedBox(height: 24));
+        widgets.add(ElevatedButton(
+          onPressed: () async {
+            await controller.pollUntilDone();
+            if (controller.status.value == PaymentStatus.paid) {
+              Get.offAllNamed(AppRoutes.bookingSuccess);
+            }
+          },
+          child: const Text('I have paid'),
+        ));
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: widgets,
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/features/payments/presentation/widgets/payment_channel_picker.dart
+++ b/lib/features/payments/presentation/widgets/payment_channel_picker.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/payment_method.dart';
+
+class PaymentChannelPicker extends StatelessWidget {
+  const PaymentChannelPicker({super.key, required this.onSelected});
+
+  final ValueChanged<PaymentMethod> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        ListTile(
+          title: const Text('Virtual Account'),
+          onTap: () => onSelected(
+            const PaymentMethod(channel: PaymentChannel.va, bankCode: 'BCA'),
+          ),
+        ),
+        ListTile(
+          title: const Text('E-Wallet'),
+          onTap: () => onSelected(
+            const PaymentMethod(channel: PaymentChannel.ewallet, ewalletType: 'OVO'),
+          ),
+        ),
+        ListTile(
+          title: const Text('QRIS'),
+          onTap: () => onSelected(
+            const PaymentMethod(channel: PaymentChannel.qris),
+          ),
+        ),
+        ListTile(
+          title: const Text('Card'),
+          onTap: () => onSelected(
+            const PaymentMethod(channel: PaymentChannel.card),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/speedboat/presentation/controllers/speedboat_controller.dart
+++ b/lib/features/speedboat/presentation/controllers/speedboat_controller.dart
@@ -52,10 +52,8 @@ class SpeedboatController extends GetxController {
       seatIds: selectedSeatIds.toList(),
       paxCount: selectedSeatIds.length,
     );
-    if (!createRes.isSuccess) return;
-    final confirmRes = await repo.confirmBooking(createRes.data!.id);
-    if (confirmRes.isSuccess) {
-      booking.value = confirmRes.data;
+    if (createRes.isSuccess) {
+      booking.value = createRes.data;
     }
   }
 }

--- a/lib/features/speedboat/presentation/pages/booking_checkout_page.dart
+++ b/lib/features/speedboat/presentation/pages/booking_checkout_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../controllers/speedboat_controller.dart';
+import '../../../../core/routes/app_routes.dart';
 
 /// Checkout page collecting user info and confirming booking.
 class BookingCheckoutPage extends StatefulWidget {
@@ -45,7 +46,7 @@ class _BookingCheckoutPageState extends State<BookingCheckoutPage> {
                   if (!_formKey.currentState!.validate()) return;
                   await controller.confirmBooking();
                   if (controller.booking.value != null) {
-                    Get.offAllNamed('/speedboat/success');
+                    Get.toNamed(AppRoutes.paymentMethod);
                   }
                 },
                 child: const Text('Confirm'),

--- a/lib/features/speedboat/presentation/pages/booking_success_page.dart
+++ b/lib/features/speedboat/presentation/pages/booking_success_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../controllers/speedboat_controller.dart';
+import '../../../payments/presentation/controllers/payment_controller.dart';
 
 /// Displays booking success information.
 class BookingSuccessPage extends GetView<SpeedboatController> {
@@ -10,6 +11,8 @@ class BookingSuccessPage extends GetView<SpeedboatController> {
   @override
   Widget build(BuildContext context) {
     final booking = controller.booking.value;
+    final paymentCtrl = Get.find<PaymentController>();
+    final intent = paymentCtrl.intent.value;
     return Scaffold(
       appBar: AppBar(title: const Text('Success')),
       body: Center(
@@ -20,6 +23,11 @@ class BookingSuccessPage extends GetView<SpeedboatController> {
                 children: [
                   Text('Booking: ${booking.id}'),
                   Text('Seats: ${booking.heldSeatIds?.join(', ')}'),
+                  if (intent != null) ...[
+                    const SizedBox(height: 8),
+                    Text('Payment: ${intent.id}'),
+                    Text('Status: ${paymentCtrl.status.value.name}'),
+                  ],
                 ],
               ),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,12 +9,22 @@ import 'features/speedboat/data/repositories/speedboat_repo_impl.dart';
 import 'features/speedboat/data/datasources/speedboat_remote_mock.dart';
 import 'features/packages/data/repositories/package_repo_impl.dart';
 import 'features/packages/data/datasources/package_remote_mock.dart';
+import 'features/payments/data/datasources/payment_gateway_mock.dart';
+import 'features/payments/data/repositories/payment_repo_impl.dart';
+import 'features/payments/presentation/controllers/payment_controller.dart';
+import 'data/storage/local_store.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   final speedboatRepo = SpeedboatRepoImpl(SpeedboatRemoteMock());
   final packageRepo = PackageRepoImpl(PackageRemoteMock());
+  final store = await LocalStore.init();
+  late PaymentRepositoryImpl payRepo;
+  final gateway = PaymentGatewayMock(onWebhook: (p) => payRepo.handleWebhook(p));
+  payRepo = PaymentRepositoryImpl(gateway: gateway, store: store, bookingRepo: speedboatRepo);
   Get.put(SpeedboatController(repo: speedboatRepo));
   Get.put(PackageDetailController(repo: packageRepo));
+  Get.put(PaymentController(payRepo));
   runApp(const TrevelinApp());
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
+  uuid: ^4.5.1
+  crypto: ^3.0.3
 
 dev_dependencies:
   flutter_test:
@@ -71,6 +73,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^4.0.0
+  mocktail: ^1.0.3
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/payments/payment_repo_test.dart
+++ b/test/payments/payment_repo_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trevelin_mobile_app/data/storage/local_store.dart';
+import 'package:trevelin_mobile_app/features/payments/data/datasources/payment_gateway_mock.dart';
+import 'package:trevelin_mobile_app/features/payments/data/repositories/payment_repo_impl.dart';
+import 'package:trevelin_mobile_app/features/payments/domain/entities/payment_method.dart';
+import 'package:trevelin_mobile_app/features/payments/domain/entities/payment_status.dart';
+import 'package:trevelin_mobile_app/features/speedboat/data/datasources/speedboat_remote_mock.dart';
+import 'package:trevelin_mobile_app/features/speedboat/data/repositories/speedboat_repo_impl.dart';
+
+void main() {
+  late PaymentRepositoryImpl repo;
+
+  setUp(() async {
+    final store = await LocalStore.init();
+    final bookingRepo = SpeedboatRepoImpl(SpeedboatRemoteMock());
+    late PaymentRepositoryImpl tmp;
+    final gateway = PaymentGatewayMock(onWebhook: (p) => tmp.handleWebhook(p));
+    tmp = PaymentRepositoryImpl(gateway: gateway, store: store, bookingRepo: bookingRepo);
+    repo = tmp;
+  });
+
+  test('create intent returns channel specific fields', () async {
+    final vaMethod = const PaymentMethod(channel: PaymentChannel.va, bankCode: 'BCA');
+    final res = await repo.createIntent(
+        bookingId: 'b1', amount: 1000, method: vaMethod, idempotencyKey: 'idem1');
+    expect(res.isSuccess, isTrue);
+    expect(res.data!.vaNumber, isNotNull);
+
+    final qrisMethod = const PaymentMethod(channel: PaymentChannel.qris);
+    final res2 = await repo.createIntent(
+        bookingId: 'b2', amount: 1000, method: qrisMethod, idempotencyKey: 'idem2');
+    expect(res2.isSuccess, isTrue);
+    expect(res2.data!.qrisPayload, isNotNull);
+  });
+
+  test('poll status becomes paid after simulation', () async {
+    final method = const PaymentMethod(channel: PaymentChannel.va, bankCode: 'BCA');
+    final create = await repo.createIntent(
+        bookingId: 'b3', amount: 1000, method: method, idempotencyKey: 'idem3');
+    final id = create.data!.id;
+    await repo.gateway.simulateProviderSetPaid(id);
+    final status = await repo.pollStatus(paymentId: id, totalTimeout: const Duration(seconds: 5));
+    expect(status.isSuccess, isTrue);
+    expect(status.data, PaymentStatus.paid);
+  });
+}

--- a/test/payments/payment_webhook_idempotency_test.dart
+++ b/test/payments/payment_webhook_idempotency_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:trevelin_mobile_app/data/storage/local_store.dart';
+import 'package:trevelin_mobile_app/features/payments/data/datasources/payment_gateway_mock.dart';
+import 'package:trevelin_mobile_app/features/payments/data/repositories/payment_repo_impl.dart';
+import 'package:trevelin_mobile_app/features/payments/domain/entities/payment_method.dart';
+import 'package:trevelin_mobile_app/features/speedboat/domain/entities/booking.dart';
+import 'package:trevelin_mobile_app/features/speedboat/domain/repositories/speedboat_repo.dart';
+import 'package:trevelin_mobile_app/core/utils/result.dart';
+
+class MockBookingRepo extends Mock implements SpeedboatRepo {}
+
+void main() {
+  late PaymentRepositoryImpl repo;
+  late MockBookingRepo bookingRepo;
+
+  setUp(() async {
+    bookingRepo = MockBookingRepo();
+    when(() => bookingRepo.confirmBooking(any())).thenAnswer((invocation) async {
+      return Result.success(Booking(
+        id: invocation.positionalArguments.first as String,
+        scheduleId: 's',
+        type: BookingType.speedboat,
+        paxCount: 1,
+        amount: 1000,
+        status: BookingStatus.paid,
+        createdAt: DateTime.now(),
+      ));
+    });
+    final store = await LocalStore.init();
+    late PaymentRepositoryImpl tmp;
+    final gateway = PaymentGatewayMock(onWebhook: (p) => tmp.handleWebhook(p));
+    tmp = PaymentRepositoryImpl(gateway: gateway, store: store, bookingRepo: bookingRepo);
+    repo = tmp;
+  });
+
+  test('handleWebhook processes once', () async {
+    final method = const PaymentMethod(channel: PaymentChannel.va, bankCode: 'BCA');
+    final create = await repo.createIntent(
+        bookingId: 'b1', amount: 1000, method: method, idempotencyKey: 'k1');
+    final id = create.data!.id;
+    final payload = {
+      'type': 'payment.paid',
+      'data': {'paymentId': id, 'status': 'paid'},
+      'signature': 'mock'
+    };
+    await repo.handleWebhook(payload);
+    await repo.handleWebhook(payload);
+    verify(() => bookingRepo.confirmBooking('b1')).called(1);
+  });
+
+  test('idempotent createIntent', () async {
+    final method = const PaymentMethod(channel: PaymentChannel.va, bankCode: 'BCA');
+    final first = await repo.createIntent(
+        bookingId: 'b2', amount: 1000, method: method, idempotencyKey: 'same');
+    final second = await repo.createIntent(
+        bookingId: 'b2', amount: 1000, method: method, idempotencyKey: 'same');
+    expect(first.data!.id, second.data!.id);
+  });
+}


### PR DESCRIPTION
## Summary
- add payment domain, repository, mock gateway and controller
- integrate checkout with payment method selection and pending screen
- support idempotent webhook handling and status polling

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze --fatal-infos --fatal-warnings` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eb0f7d3a4832782cf9e037fb29886