### PR TITLE
feat: add observability and feedback scaffolding

### DIFF
--- a/.github/workflows/flutter-release-build.yml
+++ b/.github/workflows/flutter-release-build.yml
@@ -1,0 +1,49 @@
+name: Flutter Release Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  analyze-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: dart analyze --fatal-infos --fatal-warnings
+      - run: flutter test
+
+  build-android:
+    runs-on: ubuntu-latest
+    needs: analyze-test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter build appbundle --release
+      - uses: actions/upload-artifact@v4
+        with:
+          name: appbundle
+          path: build/app/outputs/bundle/release/*.aab
+
+  build-ios:
+    runs-on: macos-latest
+    needs: analyze-test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter build ios --release --no-codesign
+      - run: zip -r build/ios/Runner.app.zip build/ios/iphoneos/Runner.app
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ios-app
+          path: build/ios/Runner.app.zip

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,6 +23,12 @@ if (flutterVersionName == null) {
     flutterVersionName = "1.0"
 }
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     namespace = "com.example.trevelin_mobile_app"
     compileSdk = flutter.compileSdkVersion
@@ -44,11 +50,32 @@ android {
         versionName = flutterVersionName
     }
 
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.debug
+            signingConfig signingConfigs.release
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'arm64-v8a', 'armeabi-v7a'
+            universalApk false
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,5 @@
+-keep class io.flutter.** { *; }
+-keep class okhttp3.** { *; }
+-keep class okio.** { *; }
+-keep class retrofit2.** { *; }
+-dontwarn javax.annotation.**

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -1,0 +1,7 @@
+# Placeholder Fastlane configuration for Android builds.
+platform :android do
+  desc "Build release AAB"
+  lane :build do
+    sh "flutter build appbundle --release"
+  end
+end

--- a/android/key.properties.example
+++ b/android/key.properties.example
@@ -1,0 +1,4 @@
+storeFile=keystore/trevelin.jks
+storePassword=changeit
+keyAlias=trevelin
+keyPassword=changeit

--- a/android/keystore/README.md
+++ b/android/keystore/README.md
@@ -1,0 +1,3 @@
+# Keystore Placeholder
+
+Place the Android keystore file here and update `../key.properties` with the correct paths and passwords. Do **not** commit real keys to source control.

--- a/assets/store/README_STORE_ASSETS.md
+++ b/assets/store/README_STORE_ASSETS.md
@@ -1,0 +1,9 @@
+# Store Listing Assets
+
+Place Google Play and App Store listing assets here.
+
+- `icons/` – application icons (adaptive, iOS, marketing).
+- `screenshots/` – screenshots for multiple device sizes.
+- `feature-graphic/` – promotional images.
+
+These are placeholders; replace with production-ready assets before release.

--- a/integration_test/booking_e2e_test.dart
+++ b/integration_test/booking_e2e_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trevelin_mobile_app/features/speedboat/data/datasources/speedboat_remote_mock.dart';
+import 'package:trevelin_mobile_app/features/speedboat/data/repositories/speedboat_repo_impl.dart';
+import 'package:trevelin_mobile_app/features/speedboat/domain/entities/booking.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('booking flow reaches paid status', () async {
+    final repo = SpeedboatRepoImpl(SpeedboatRemoteMock());
+    final create = await repo.createBooking(
+      scheduleId: 'sch-001',
+      seatIds: ['s1', 's2'],
+      paxCount: 2,
+    );
+    expect(create.isSuccess, isTrue);
+    final confirm = await repo.confirmBooking(create.data!.id);
+    expect(confirm.isSuccess, isTrue);
+    expect(confirm.data!.status, BookingStatus.paid);
+  });
+}

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -34,8 +34,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
+  <key>UISupportedInterfaceOrientations~ipad</key>
+  <array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
@@ -43,7 +43,11 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+  <key>UIApplicationSupportsIndirectInputEvents</key>
+  <true/>
+  <key>NSCameraUsageDescription</key>
+  <string>Camera access is required for QR scanning.</string>
+  <key>NSLocationWhenInUseUsageDescription</key>
+  <string>Location is used to show nearby services.</string>
 </dict>
 </plist>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,0 +1,7 @@
+# Placeholder Fastlane configuration for iOS builds.
+platform :ios do
+  desc "Build iOS archive"
+  lane :build do
+    sh "flutter build ios --release --no-codesign"
+  end
+end

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -1,0 +1,12 @@
+{
+  "appTitle": "Trevelin",
+  "bookNow": "Book now",
+  "payNow": "Pay now",
+  "feedbackTitle": "Feedback",
+  "errorGeneric": "Something went wrong",
+  "subjectLabel": "Subject",
+  "descriptionLabel": "Description",
+  "includeLogsLabel": "Include logs",
+  "feedbackThanks": "Thanks for your feedback!",
+  "submitLabel": "Submit"
+}

--- a/l10n/app_id.arb
+++ b/l10n/app_id.arb
@@ -1,0 +1,12 @@
+{
+  "appTitle": "Trevelin",
+  "bookNow": "Pesan sekarang",
+  "payNow": "Bayar sekarang",
+  "feedbackTitle": "Masukan",
+  "errorGeneric": "Terjadi kesalahan",
+  "subjectLabel": "Subjek",
+  "descriptionLabel": "Deskripsi",
+  "includeLogsLabel": "Sertakan log",
+  "feedbackThanks": "Terima kasih atas masukan Anda!",
+  "submitLabel": "Kirim"
+}

--- a/lib/core/diagnostics/device_info.dart
+++ b/lib/core/diagnostics/device_info.dart
@@ -1,0 +1,36 @@
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Collects basic device and application information for diagnostics/feedback.
+class DeviceInfoCollector {
+  DeviceInfoCollector._();
+
+  static Future<Map<String, String>> collect() async {
+    final deviceInfo = DeviceInfoPlugin();
+    final package = await PackageInfo.fromPlatform();
+    final data = <String, String>{
+      'appName': package.appName,
+      'packageName': package.packageName,
+      'version': package.version,
+      'buildNumber': package.buildNumber,
+    };
+    try {
+      final android = await deviceInfo.androidInfo;
+      data.addAll({
+        'platform': 'android',
+        'model': android.model ?? '',
+        'sdkInt': '${android.version.sdkInt}',
+      });
+    } catch (_) {
+      try {
+        final ios = await deviceInfo.iosInfo;
+        data.addAll({
+          'platform': 'ios',
+          'model': ios.utsname.machine ?? '',
+          'systemVersion': ios.systemVersion ?? '',
+        });
+      } catch (_) {}
+    }
+    return data;
+  }
+}

--- a/lib/core/logging/app_logger.dart
+++ b/lib/core/logging/app_logger.dart
@@ -1,0 +1,13 @@
+import 'package:logger/logger.dart';
+
+/// Global application logger using the [logger] package.
+class AppLogger {
+  AppLogger._();
+
+  static final Logger _logger = Logger(printer: PrettyPrinter(methodCount: 0));
+
+  static void d(String message, [dynamic data]) => _logger.d(message, data);
+
+  static void e(String message, [dynamic error, StackTrace? stackTrace]) =>
+      _logger.e(message, error, stackTrace);
+}

--- a/lib/core/logging/http_logger_interceptor.dart
+++ b/lib/core/logging/http_logger_interceptor.dart
@@ -1,0 +1,23 @@
+import 'package:dio/dio.dart';
+import 'app_logger.dart';
+
+/// Logs HTTP requests and responses without including bodies for PII safety.
+class HttpLoggerInterceptor extends Interceptor {
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    AppLogger.d('REQ ${options.method} ${options.uri}');
+    handler.next(options);
+  }
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    AppLogger.d('RES ${response.statusCode} ${response.requestOptions.uri}');
+    handler.next(response);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    AppLogger.e('HTTP ERR ${err.requestOptions.uri}', err, err.stackTrace);
+    handler.next(err);
+  }
+}

--- a/lib/core/routes/app_routes.dart
+++ b/lib/core/routes/app_routes.dart
@@ -7,6 +7,10 @@ import '../../features/speedboat/presentation/pages/booking_success_page.dart';
 import '../../features/packages/presentation/pages/package_detail_page.dart';
 import '../../features/payments/presentation/pages/payment_method_page.dart';
 import '../../features/payments/presentation/pages/payment_pending_page.dart';
+import '../../features/feedback/presentation/pages/feedback_page.dart';
+import '../../features/feedback/presentation/controllers/feedback_controller.dart';
+import '../../features/feedback/data/feedback_sender.dart';
+import '../../features/debugtools/presentation/pages/debug_menu_page.dart';
 
 /// Application route names and GetX pages.
 class AppRoutes {
@@ -20,6 +24,8 @@ class AppRoutes {
   static const String paymentMethod = '/payment/method';
   static const String paymentPending = '/payment/pending';
   static const String packageDetail = '/package/:id';
+  static const String feedback = '/feedback';
+  static const String debugMenu = '/debug';
 
   /// List of [GetPage] for GetMaterialApp.
   static final List<GetPage<dynamic>> pages = [
@@ -31,5 +37,13 @@ class AppRoutes {
     GetPage(name: paymentMethod, page: () => const PaymentMethodPage()),
     GetPage(name: paymentPending, page: () => const PaymentPendingPage()),
     GetPage(name: packageDetail, page: () => const PackageDetailPage()),
+    GetPage(
+      name: feedback,
+      page: () => const FeedbackPage(),
+      binding: BindingsBuilder(() {
+        Get.put(FeedbackController(EmailFeedbackSender()));
+      }),
+    ),
+    GetPage(name: debugMenu, page: () => const DebugMenuPage()),
   ];
 }

--- a/lib/core/telemetry/analytics.dart
+++ b/lib/core/telemetry/analytics.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/foundation.dart';
+
+/// Abstraction for analytics events.
+abstract class Analytics {
+  Future<void> init();
+  void log(String event, {Map<String, Object?> params = const {}});
+}
+
+/// Console implementation used for development/testing.
+class ConsoleAnalytics implements Analytics {
+  @override
+  Future<void> init() async {}
+
+  @override
+  void log(String event, {Map<String, Object?> params = const {}}) {
+    debugPrint('[ANALYTICS] $event $params');
+  }
+}
+
+/// Canonical analytics events used by the app.
+class AnalyticsEvents {
+  AnalyticsEvents._();
+
+  static const searchPerformed = 'search_performed';
+  static const scheduleViewed = 'schedule_viewed';
+  static const seatSelected = 'seat_selected';
+  static const bookingInitiated = 'booking_initiated';
+  static const paymentIntentCreated = 'payment_intent_created';
+  static const paymentPaid = 'payment_paid';
+  static const packageViewed = 'package_viewed';
+  static const feedbackSent = 'feedback_sent';
+}

--- a/lib/core/telemetry/crash_reporter.dart
+++ b/lib/core/telemetry/crash_reporter.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/foundation.dart';
+
+/// Abstraction around crash reporting so implementations can be swapped.
+abstract class CrashReporter {
+  Future<void> init();
+  void recordError(Object error, StackTrace stack,
+      {Map<String, String>? tags});
+  void setUserId(String? id);
+}
+
+/// Default console implementation which simply prints errors.
+class CrashReporterConsole implements CrashReporter {
+  @override
+  Future<void> init() async {}
+
+  @override
+  void recordError(Object error, StackTrace stack,
+      {Map<String, String>? tags}) {
+    debugPrint('[CRASH] $error\n$stack');
+  }
+
+  @override
+  void setUserId(String? id) {}
+}
+
+// TODO: add CrashReporterFirebase implementation when Firebase is configured.

--- a/lib/core/utils/retry.dart
+++ b/lib/core/utils/retry.dart
@@ -1,20 +1,26 @@
 /// Retry a future-returning function with exponential backoff.
+import 'dart:math';
+
+/// Retry a future-returning function with jittered exponential backoff.
+///
+/// Each retry waits for `baseDelay * 2^(attempt-1)` and applies random jitter
+/// up to that duration to prevent thundering herds.
 Future<T> retryWithBackoff<T>(
   Future<T> Function() fn, {
   int maxAttempts = 6,
+  Duration baseDelay = const Duration(milliseconds: 500),
 }) async {
   var attempt = 0;
-  var delay = const Duration(seconds: 1);
-  late T result;
+  final rand = Random();
   while (true) {
     try {
-      result = await fn();
-      return result;
+      return await fn();
     } catch (_) {
       attempt++;
       if (attempt >= maxAttempts) rethrow;
-      await Future.delayed(delay);
-      delay *= 2;
+      final exp = baseDelay.inMilliseconds * pow(2, attempt - 1);
+      final jitterMs = rand.nextInt(exp.toInt() + 1);
+      await Future.delayed(Duration(milliseconds: jitterMs));
     }
   }
 }

--- a/lib/data/network/dio_client.dart
+++ b/lib/data/network/dio_client.dart
@@ -1,16 +1,45 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../core/logging/http_logger_interceptor.dart';
+import '../../core/utils/retry.dart';
 
 /// Provides a simple [Dio] client with logging enabled.
 class DioClient {
   DioClient._();
 
   static Dio create() {
-    final dio = Dio(BaseOptions(
-      baseUrl: 'https://mock.trevelin',
-      connectTimeout: const Duration(seconds: 5),
-      receiveTimeout: const Duration(seconds: 5),
-    ));
-    dio.interceptors.add(LogInterceptor(responseBody: true));
+    final dio = Dio(
+      BaseOptions(
+        baseUrl: 'https://mock.trevelin',
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 10),
+      ),
+    );
+
+    // Only log HTTP traffic in debug builds.
+    if (!kReleaseMode) {
+      dio.interceptors.add(HttpLoggerInterceptor());
+    }
+
+    // Retry idempotent GET requests with backoff.
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onError: (e, handler) async {
+          if (e.requestOptions.method.toUpperCase() == 'GET' &&
+              e.type != DioExceptionType.cancel &&
+              e.requestOptions.extra['retries'] == null) {
+            e.requestOptions.extra['retries'] = 1;
+            try {
+              final response = await retryWithBackoff(() => dio.fetch(e.requestOptions));
+              return handler.resolve(response);
+            } catch (_) {}
+          }
+          handler.next(e);
+        },
+      ),
+    );
+
     return dio;
   }
 }

--- a/lib/data/storage/local_store.dart
+++ b/lib/data/storage/local_store.dart
@@ -13,4 +13,5 @@ class LocalStore {
 
   T? read<T>(String key) => _box.read<T>(key);
   Future<void> write(String key, dynamic value) => _box.write(key, value);
+  Future<void> remove(String key) => _box.remove(key);
 }

--- a/lib/features/debugtools/presentation/pages/debug_menu_page.dart
+++ b/lib/features/debugtools/presentation/pages/debug_menu_page.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../feedback/data/feedback_sender.dart';
+import '../../feedback/presentation/controllers/feedback_controller.dart';
+import '../../feedback/presentation/pages/feedback_page.dart';
+
+/// Simple debug menu available only in non-release builds.
+class DebugMenuPage extends StatelessWidget {
+  const DebugMenuPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    if (kReleaseMode) {
+      return const SizedBox.shrink();
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Debug Menu')),
+      body: ListView(
+        children: [
+          ListTile(
+            title: const Text('Throw test error'),
+            onTap: () => throw Exception('Test error from debug menu'),
+          ),
+          ListTile(
+            title: const Text('Open feedback'),
+            onTap: () => Get.to(() => const FeedbackPage(),
+                binding: BindingsBuilder(() {
+                  Get.put(FeedbackController(EmailFeedbackSender()));
+                })),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/feedback/data/feedback_sender.dart
+++ b/lib/features/feedback/data/feedback_sender.dart
@@ -1,0 +1,25 @@
+import 'package:url_launcher/url_launcher.dart';
+
+/// Abstraction for sending feedback information.
+abstract class FeedbackSender {
+  Future<void> send(String subject, String body);
+}
+
+/// Simple implementation that launches the mail client.
+class EmailFeedbackSender implements FeedbackSender {
+  EmailFeedbackSender({this.to = 'support@trevelin.example'});
+
+  final String to;
+
+  @override
+  Future<void> send(String subject, String body) async {
+    final uri = Uri(
+      scheme: 'mailto',
+      path: to,
+      queryParameters: {'subject': subject, 'body': body},
+    );
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
+}

--- a/lib/features/feedback/presentation/controllers/feedback_controller.dart
+++ b/lib/features/feedback/presentation/controllers/feedback_controller.dart
@@ -1,0 +1,31 @@
+import 'package:get/get.dart';
+
+import '../../../../core/diagnostics/device_info.dart';
+import '../../data/feedback_sender.dart';
+
+/// Controller powering the [FeedbackPage].
+class FeedbackController extends GetxController {
+  FeedbackController(this.sender);
+
+  final FeedbackSender sender;
+
+  final subject = ''.obs;
+  final description = ''.obs;
+  final includeLogs = false.obs;
+
+  final Map<String, String> _deviceInfo = {};
+
+  @override
+  void onInit() {
+    super.onInit();
+    DeviceInfoCollector.collect().then(_deviceInfo.addAll);
+  }
+
+  Future<void> submit() async {
+    final buffer = StringBuffer()
+      ..writeln(description.value)
+      ..writeln('\n---')
+      ..writeln(_deviceInfo.entries.map((e) => '${e.key}: ${e.value}').join('\n'));
+    await sender.send(subject.value, buffer.toString());
+  }
+}

--- a/lib/features/feedback/presentation/pages/feedback_page.dart
+++ b/lib/features/feedback/presentation/pages/feedback_page.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import '../controllers/feedback_controller.dart';
+
+/// Page allowing users to send in-app feedback.
+class FeedbackPage extends GetView<FeedbackController> {
+  const FeedbackPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.feedbackTitle)),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              decoration: InputDecoration(labelText: l10n.subjectLabel),
+              onChanged: controller.subject.call,
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              decoration: InputDecoration(labelText: l10n.descriptionLabel),
+              maxLines: 5,
+              onChanged: controller.description.call,
+            ),
+            const SizedBox(height: 8),
+            Obx(() => SwitchListTile(
+                  title: Text(l10n.includeLogsLabel),
+                  value: controller.includeLogs.value,
+                  onChanged: (v) => controller.includeLogs.value = v,
+                )),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                await controller.submit();
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(l10n.feedbackThanks)));
+                  Get.back();
+                }
+              },
+              child: Text(l10n.submitLabel),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/packages/presentation/widgets/package_gallery.dart
+++ b/lib/features/packages/presentation/widgets/package_gallery.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
 /// Simple placeholder gallery using [PageView].
@@ -13,10 +14,21 @@ class PackageGallery extends StatelessWidget {
       child: PageView.builder(
         itemCount: images.length,
         itemBuilder: (context, index) {
-          return Container(
-            margin: const EdgeInsets.all(4),
-            color: Colors.blueGrey,
-            child: Center(child: Text(images[index])),
+          final url = images[index];
+          // Precache first image for smoother experience.
+          if (index == 0) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              precacheImage(CachedNetworkImageProvider(url), context);
+            });
+          }
+          return Semantics(
+            label: 'Gallery image ${index + 1}',
+            child: CachedNetworkImage(
+              imageUrl: url,
+              fit: BoxFit.cover,
+              placeholder: (c, _) => const Center(child: CircularProgressIndicator()),
+              errorWidget: (c, _, __) => const Icon(Icons.broken_image),
+            ),
           );
         },
       ),

--- a/lib/features/speedboat/presentation/widgets/seat_grid.dart
+++ b/lib/features/speedboat/presentation/widgets/seat_grid.dart
@@ -27,15 +27,20 @@ class SeatGrid extends StatelessWidget {
         } else {
           color = Colors.white;
         }
-        return GestureDetector(
-          onTap: seat.status == SeatStatus.sold ? null : () => onTap(seat.id),
-          child: Container(
-            margin: const EdgeInsets.all(4),
-            decoration: BoxDecoration(
-              color: color,
-              border: Border.all(color: Colors.black),
+        return Semantics(
+          label: 'Seat ${seat.code}',
+          button: true,
+          enabled: seat.status != SeatStatus.sold,
+          child: GestureDetector(
+            onTap: seat.status == SeatStatus.sold ? null : () => onTap(seat.id),
+            child: Container(
+              margin: const EdgeInsets.all(4),
+              decoration: BoxDecoration(
+                color: color,
+                border: Border.all(color: Colors.black),
+              ),
+              child: Center(child: Text(seat.code)),
             ),
-            child: Center(child: Text(seat.code)),
           ),
         );
       },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'core/theme/app_theme.dart';
 import 'core/routes/app_routes.dart';
@@ -13,31 +16,57 @@ import 'features/payments/data/datasources/payment_gateway_mock.dart';
 import 'features/payments/data/repositories/payment_repo_impl.dart';
 import 'features/payments/presentation/controllers/payment_controller.dart';
 import 'data/storage/local_store.dart';
+import 'core/logging/app_logger.dart';
+import 'core/telemetry/analytics.dart';
+import 'core/telemetry/crash_reporter.dart';
 
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  final speedboatRepo = SpeedboatRepoImpl(SpeedboatRemoteMock());
-  final packageRepo = PackageRepoImpl(PackageRemoteMock());
-  final store = await LocalStore.init();
-  late PaymentRepositoryImpl payRepo;
-  final gateway = PaymentGatewayMock(onWebhook: (p) => payRepo.handleWebhook(p));
-  payRepo = PaymentRepositoryImpl(gateway: gateway, store: store, bookingRepo: speedboatRepo);
-  Get.put(SpeedboatController(repo: speedboatRepo));
-  Get.put(PackageDetailController(repo: packageRepo));
-  Get.put(PaymentController(payRepo));
-  runApp(const TrevelinApp());
+Future<void> main() async {
+  FlutterError.onError = (details) {
+    Zone.current.handleUncaughtError(details.exception, details.stack!);
+  };
+
+  late CrashReporter crash;
+
+  await runZonedGuarded(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    crash = CrashReporterConsole();
+    await crash.init();
+    final analytics = ConsoleAnalytics();
+    await analytics.init();
+
+    final speedboatRepo = SpeedboatRepoImpl(SpeedboatRemoteMock());
+    final packageRepo = PackageRepoImpl(PackageRemoteMock());
+    final store = await LocalStore.init();
+    late PaymentRepositoryImpl payRepo;
+    final gateway =
+        PaymentGatewayMock(onWebhook: (p) => payRepo.handleWebhook(p));
+    payRepo = PaymentRepositoryImpl(
+        gateway: gateway, store: store, bookingRepo: speedboatRepo);
+    Get.put(SpeedboatController(repo: speedboatRepo));
+    Get.put(PackageDetailController(repo: packageRepo));
+    Get.put(PaymentController(payRepo));
+    runApp(TrevelinApp(analytics: analytics, crash: crash));
+  }, (error, stack) {
+    AppLogger.e('Uncaught zone error', error, stack);
+    crash.recordError(error, stack);
+  });
 }
 
 class TrevelinApp extends StatelessWidget {
-  const TrevelinApp({super.key});
+  const TrevelinApp({super.key, required this.analytics, required this.crash});
+
+  final Analytics analytics;
+  final CrashReporter crash;
 
   @override
   Widget build(BuildContext context) {
     return GetMaterialApp(
-      title: 'Trevelin',
+      title: AppLocalizations.of(context)?.appTitle ?? 'Trevelin',
       theme: AppTheme.light,
       getPages: AppRoutes.pages,
       initialRoute: AppRoutes.speedboat,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,12 @@ dependencies:
   dio: ^5.4.3+1
   pretty_dio_logger: ^1.3.1
   connectivity_plus: ^6.0.3
+  url_launcher: ^6.3.0
+
+  # Device & app info
+  device_info_plus: ^10.1.0
+  package_info_plus: ^8.0.0
+  logger: ^2.0.2
 
   # UI/UX Components
   flutter_screenutil: ^5.9.0
@@ -54,6 +60,8 @@ dependencies:
   # Date & Time
   intl: ^0.19.0
   table_calendar: ^3.0.9
+  flutter_localizations:
+    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -66,6 +74,8 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.4.9
   json_serializable: ^6.8.0
+  integration_test:
+    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
@@ -84,6 +94,7 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+  generate: true
 
   # To add assets to your application, add an assets section, like this:
   # assets:

--- a/test/a11y/semantics_smoke_test.dart
+++ b/test/a11y/semantics_smoke_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:trevelin_mobile_app/features/speedboat/data/datasources/speedboat_remote_mock.dart';
+import 'package:trevelin_mobile_app/features/speedboat/data/repositories/speedboat_repo_impl.dart';
+import 'package:trevelin_mobile_app/features/speedboat/presentation/controllers/speedboat_controller.dart';
+import 'package:trevelin_mobile_app/features/speedboat/presentation/pages/seat_map_page.dart';
+
+void main() {
+  testWidgets('seat has semantics label', (tester) async {
+    final repo = SpeedboatRepoImpl(SpeedboatRemoteMock());
+    final controller = SpeedboatController(repo: repo);
+    Get.put(controller);
+    controller.loadSeatMap('sch-001');
+    await tester.pumpWidget(const GetMaterialApp(home: SeatMapPage()));
+    await tester.pumpAndSettle();
+    final node = tester.getSemantics(find.text('s1'));
+    expect(node.label, 'Seat s1');
+  });
+}

--- a/test/core/logger_sanity_test.dart
+++ b/test/core/logger_sanity_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trevelin_mobile_app/core/logging/app_logger.dart';
+
+void main() {
+  test('logger methods execute without throwing', () {
+    expect(() => AppLogger.d('debug message'), returnsNormally);
+    expect(
+        () => AppLogger.e('error message', Exception('oops'), StackTrace.current),
+        returnsNormally);
+  });
+}

--- a/test/core/retry_test.dart
+++ b/test/core/retry_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trevelin_mobile_app/core/utils/retry.dart';
+
+void main() {
+  test('retries until success or max attempts', () async {
+    var attempts = 0;
+    Future<void> failing() async {
+      attempts++;
+      if (attempts < 3) throw Exception('fail');
+    }
+
+    await retryWithBackoff(failing, maxAttempts: 3);
+    expect(attempts, 3);
+  });
+}


### PR DESCRIPTION
## Summary
- wire up crash reporting, analytics, logging and jittered retry
- add feedback page and debug menu with device info collector
- set up release build workflow and Android/iOS build configs

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze --fatal-infos --fatal-warnings` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*
- `flutter test integration_test` *(fails: command not found)*
- `flutter build appbundle --release` *(fails: command not found)*
- `flutter build ios --release --no-codesign` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eb312d1e083278b4fbf84b50aafa3