### PR TITLE
chore: relax package import lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -33,7 +33,6 @@ analyzer:
     - "**/*.g.dart"
 linter:
   rules:
-    always_use_package_imports: true
     avoid_print: true
     prefer_final_locals: true
     prefer_const_constructors: true


### PR DESCRIPTION
## Summary
- remove package-import lint to match existing relative imports

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ee7c80c008327a91112ad3ca18f99